### PR TITLE
Essential updates for older Salt versions

### DIFF
--- a/intellij/env.sls
+++ b/intellij/env.sls
@@ -25,7 +25,7 @@ intellij-home-alt-set:
     - name: intellij-home
     - path: {{ intellij.intellij_real_home }}
     - require:
-      - intellij-home-alt-install
+      - alternatives: intellij-home-alt-install
 
 # Add intelli to alternatives system
 intellij-alt-install:
@@ -35,12 +35,12 @@ intellij-alt-install:
     - path: {{ intellij.intellij_realcmd }}
     - priority: {{ intellij.alt_priority }}
     - require:
-      - intellij-home-alt-set
+      - alternatives: intellij-home-alt-set
 
 intellij-alt-set:
   alternatives.set:
     - name: intellij
     - path: {{ intellij.intellij_realcmd }}
     - require:
-      - intellij-alt-install
+      - alternatives: intellij-alt-install
 

--- a/intellij/init.sls
+++ b/intellij/init.sls
@@ -27,7 +27,7 @@ intellij-download-archive:
     - name: curl {{ intellij.dl_opts }} -o '{{ archive_file }}' '{{ intellij.source_url }}'
     - unless: test -f '{{ intellij.intellij_realcmd }}'
     - require:
-      - file: intellij-remove-prev-archive
+      - file: intellij-install-dir
 
 intellij-unpacked-dir:
   file.directory:

--- a/intellij/init.sls
+++ b/intellij/init.sls
@@ -27,7 +27,7 @@ intellij-download-archive:
     - name: curl {{ intellij.dl_opts }} -o '{{ archive_file }}' '{{ intellij.source_url }}'
     - unless: test -f '{{ intellij.intellij_realcmd }}'
     - require:
-      - intellij-remove-prev-archive
+      - file: intellij-remove-prev-archive
 
 intellij-unpacked-dir:
   file.directory:

--- a/intellij/init.sls
+++ b/intellij/init.sls
@@ -25,7 +25,6 @@ intellij-remove-prev-archive:
 intellij-download-archive:
   cmd.run:
     - name: curl {{ intellij.dl_opts }} -o '{{ archive_file }}' '{{ intellij.source_url }}'
-    - unless: test -f '{{ intellij.intellij_realcmd }}'
     - require:
       - file: intellij-install-dir
 

--- a/intellij/init.sls
+++ b/intellij/init.sls
@@ -19,14 +19,14 @@ intellij-install-dir:
 {{ archive_file }}:
   file.absent:
     - require_in:
-      - intellij-download-archive
+      - cmd: intellij-download-archive
 
 intellij-download-archive:
   cmd.run:
     - name: curl {{ intellij.dl_opts }} -o '{{ archive_file }}' '{{ intellij.source_url }}'
     - unless: test -f '{{ intellij.intellij_realcmd }}'
     - require:
-      - intellij-install-dir
+      - file: intellij-install-dir
 
 intellij-unpacked-dir:
   file.directory:
@@ -35,8 +35,9 @@ intellij-unpacked-dir:
     - group: root
     - mode: 755
     - makedirs: True
+    - force: True
     - require:
-      - intellij-download-archive
+      - cmd: intellij-download-archive
 
 intellij-unpack-archive:
   archive.extracted:
@@ -46,13 +47,15 @@ intellij-unpack-archive:
     - source_hash: {{ intellij.source_hash }}
     {%- endif %}
     - archive_format: {{ intellij.archive_type }}
+  {% if grains['saltversioninfo'] < [2016, 11, 0] %}
+    - tar_options: {{ intellij.unpack_opts }}
+    - if_missing: {{ intellij.intellij_realcmd }}
+  {% else %}
     - options: {{ intellij.unpack_opts }}
+  {% endif %}
     - enforce_toplevel: False
-    - clean: True
-    - user: root
-    - group: root
     - onchanges:
-      - intellij-unpacked-dir
+      - file: intellij-unpacked-dir
 
 intellij-update-home-symlink:
   file.symlink:
@@ -60,14 +63,14 @@ intellij-update-home-symlink:
     - target: {{ intellij.intellij_real_home }}
     - force: True
     - require:
-      - intellij-unpack-archive
+      - archive: intellij-unpack-archive
 
 intellij-desktop-entry:
   file.managed:
     - source: salt://intellij/files/intellij.desktop
     - name: /home/{{ pillar['user'] }}/Desktop/intellij.desktop
     - user: {{ pillar['user'] }}
-{% if salt['grains.get']('os_family') == 'Suse' %}
+{% if salt['grains.get']('os_family') == 'Suse' or salt['grains.get']('os') == 'SUSE' %}
     - group: users
 {% else %}
     - group: {{ pillar['user'] }}
@@ -75,20 +78,20 @@ intellij-desktop-entry:
     - mode: 755
     - force: True
     - require:
-      - intellij-unpack-archive
+      - archive: intellij-unpack-archive
 
 intellij-remove-archive:
   file.absent:
     - name: {{ archive_file }}
     - require:
-      - intellij-unpack-archive
+      - archive: intellij-unpack-archive
 
 {%- if intellij.source_hash %}
 intellij-remove-archive-hashfile:
   file.absent:
     - name: {{ archive_file }}.sha256
     - require:
-      - intellij-unpack-archive
+      - archive: intellij-unpack-archive
 {%- endif %}
 
 {%- endif %}

--- a/intellij/init.sls
+++ b/intellij/init.sls
@@ -16,17 +16,18 @@ intellij-install-dir:
 
 # curl fails (rc=23) if file exists
 # and test -f cannot detect corrupt archive
-{{ archive_file }}:
+intellij-remove-prev-archive:
   file.absent:
-    - require_in:
-      - cmd: intellij-download-archive
+    - name: {{ archive_file }}
+    - require:
+      - file: intellij-install-dir
 
 intellij-download-archive:
   cmd.run:
     - name: curl {{ intellij.dl_opts }} -o '{{ archive_file }}' '{{ intellij.source_url }}'
     - unless: test -f '{{ intellij.intellij_realcmd }}'
     - require:
-      - file: intellij-install-dir
+      - intellij-remove-prev-archive
 
 intellij-unpacked-dir:
   file.directory:
@@ -54,8 +55,8 @@ intellij-unpack-archive:
     - options: {{ intellij.unpack_opts }}
   {% endif %}
     - enforce_toplevel: False
-    - onchanges:
-      - file: intellij-unpacked-dir
+    - require:
+      - cmd: intellij-download-archive
 
 intellij-update-home-symlink:
   file.symlink:

--- a/intellij/init.sls
+++ b/intellij/init.sls
@@ -53,7 +53,9 @@ intellij-unpack-archive:
   {% else %}
     - options: {{ intellij.unpack_opts }}
   {% endif %}
+  {% if grains['saltversioninfo'] >= [2016, 11, 0] %}
     - enforce_toplevel: False
+  {% endif %}
     - require:
       - cmd: intellij-download-archive
 

--- a/intellij/settings.sls
+++ b/intellij/settings.sls
@@ -4,13 +4,20 @@
 {%- set intellij_home   = salt['grains.get']('intellij_home', salt['pillar.get']('intellij_home', '/opt/intellij')) %}
 
 {%- set year                 = g.get('year', p.get('year', '17' )) %}
-{%- set release              = g.get('release', p.get('release','1.4' )) %}
+{%- set release              = g.get('release', p.get('release','2' )) %}
 {%- set mirror1              = 'https://download-cf.jetbrains.com/idea/' %}
 {%- set mirror2              = 'https://download.jetbrains.com/idea/' %}
 
 {%- set default_prefix       = '/usr/share/java' %}
 {%- set default_source_url   = mirror1 + 'ideaIC-20' + year + '.' + release + '-no-jdk.tar.gz' %}
-{%- set default_source_hash  = mirror2 + 'ideaIC-20' + year + '.' + release + '-no-jdk.tar.gz' + '.sha256' %}
+
+{% if salt['grains.get']('saltversioninfo') <= [2016, 11, 6] %}
+   ######## version 2017.2 hash ######
+   {%- set default_source_hash  = 'sha256=d88257b17447398ed60e7d774803cbc21e0fe7750add09622a98b936f14cd91f' %}
+{% else %}
+   {%- set default_source_hash  = mirror2 + 'ideaIC-20' + year + '.' + release + '-no-jdk.tar.gz' + '.sha256' %}
+{% endif %}
+
 {%- set default_dl_opts      = ' -s ' %}
 {%- set default_real_home    = default_prefix + '/idea-IC-' + year + release %}
 {%- set default_unpack_opts  = 'z -C ' + default_real_home + ' --strip-components=1' %}


### PR DESCRIPTION
This PR takes newer INTELLIJ 2017.2 version and addresses number of issues-

1. **Salt 2015.8.8 (Beryllium) generates "Requisite declaration XXXXXXXXXXX in SLS eclipse-java is not formed as a single key dictionary"**  errors for all the "requires" and "requires_in" parameters in formula.

        Solution: Prefix the correct type of requisite (i.e. - file: eclipse-java-desktop-entry )

2.  **Salt 2016.3 on OpenSuSE Leap evaluates "salt['grains.get']('os_family') == 'Suse'" as False.**

        Solution: Using "salt['grains.get']('os') == 'SUSE'" instead works!

3. **Current "saltversion" check does not work on opensuse leap.**

       Solution: Twooster on #salt IRC suggested "{% if grains['saltversioninfo'] <= [2016, 11, 6] %}" which works!!

4. **Salt archive.extracted warns "clean: True" parameter is invalid.**

        Solution: Remove "clean: True" parameter.

5. **Salt generates warnings on Fedora regarding https://github.com/saltstack/salt/issues/39751**

        Solution: Remove "user: root" and "group: root" from archive.extracted state.

6. **Salt archive.extracted.options is needed, but older Salt needs tar_options instead.**

        Solution:  Enclose archive.extracted options/tar_options parameters = fix error.

7. **Salt 2016.3 on opensuse Leap complains about source_hash="https".** 

        Solution: update settings.sls to support source_hash=sha256 for older Salt.

8.  **On older Salt version the archive is never extracted because directory "name" exists** 

        Solution: Reintroduce "if_missing" parameter to archive.extracted for older Salt.

9. **The state name "{{ archive_file }}: was triggering "Recursive Requisite found" on Fed/Ubun.**

       Solution:  Don't use "{{ archive_file }}" for file.absent state name!!

Tested successfuly (no pillars):
- Fedora 25 / Salt 2016.11.3.1.fc25
- Ubunutu 17 / Salt 2017.7.0+ds-1
- Opensuse Leap / Salt 2016.3.4.84.13
