### PR TITLE
use onchanges; fix desktop icon path; fix hashchecks in older salt

### DIFF
--- a/intellij/env.sls
+++ b/intellij/env.sls
@@ -26,6 +26,8 @@ intellij-home-alt-set:
     - path: {{ intellij.intellij_real_home }}
     - require:
       - alternatives: intellij-home-alt-install
+    - onchanges:
+      - alternatives: intellij-home-alt-install
 
 # Add intelli to alternatives system
 intellij-alt-install:
@@ -36,11 +38,15 @@ intellij-alt-install:
     - priority: {{ intellij.alt_priority }}
     - require:
       - alternatives: intellij-home-alt-set
+    - onchanges:
+      - alternatives: intellij-home-alt-set
 
 intellij-alt-set:
   alternatives.set:
     - name: intellij
     - path: {{ intellij.intellij_realcmd }}
     - require:
+      - alternatives: intellij-alt-install
+    - onchanges:
       - alternatives: intellij-alt-install
 

--- a/intellij/files/intellij.desktop
+++ b/intellij/files/intellij.desktop
@@ -2,7 +2,7 @@
 Encoding=UTF-8
 Name=IDEA IntelliJ
 Comment=JetBrains IntelliJ IDEA (Java IDE)
-Icon=/opt/intellij/icon.png
+Icon=/opt/intellij/bin/idea.png
 Exec=idea.sh
 Terminal=false
 Type=Application

--- a/intellij/init.sls
+++ b/intellij/init.sls
@@ -70,8 +70,8 @@ intellij-unpack-archive:
     - enforce_toplevel: False
   {% endif %}
     - archive_format: {{ intellij.archive_type }}
-    - require:
-      - file: intellij-unpacked-dir
+    - onchanges:
+      - cmd: intellij-download-archive
 
 intellij-update-home-symlink:
   file.symlink:

--- a/intellij/init.sls
+++ b/intellij/init.sls
@@ -38,6 +38,8 @@ intellij-unpacked-dir:
     - force: True
     - require:
       - cmd: intellij-download-archive
+    - onchanges:
+      - cmd: intellij-download-archive
 
 intellij-unpack-archive:
   archive.extracted:
@@ -58,6 +60,8 @@ intellij-unpack-archive:
   {% endif %}
     - require:
       - cmd: intellij-download-archive
+    - onchanges:
+      - cmd: intellij-download-archive
 
 intellij-update-home-symlink:
   file.symlink:
@@ -65,6 +69,8 @@ intellij-update-home-symlink:
     - target: {{ intellij.intellij_real_home }}
     - force: True
     - require:
+      - archive: intellij-unpack-archive
+    - onchanges:
       - archive: intellij-unpack-archive
 
 intellij-desktop-entry:
@@ -84,16 +90,10 @@ intellij-desktop-entry:
 
 intellij-remove-archive:
   file.absent:
-    - name: {{ archive_file }}
+    - names:
+      - {{ archive_file }}
+      - {{ archive_file }}.sha256
     - require:
       - archive: intellij-unpack-archive
-
-{%- if intellij.source_hash %}
-intellij-remove-archive-hashfile:
-  file.absent:
-    - name: {{ archive_file }}.sha256
-    - require:
-      - archive: intellij-unpack-archive
-{%- endif %}
 
 {%- endif %}


### PR DESCRIPTION
improvements:

(1) intellij or intellij.env state failure triggers unnecessary dep-states failure => use onchanges.
(2) Fix desktop icon - this is command line utility.
(3) Ensure hashcheck happens for older salt versions.