### PR TITLE
Minor fixes for Intellij.init and intellij.developer states

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,8 +34,7 @@ On Linux, the PATH is set for all system users by adding software profile to /et
 
 .. note::
 
-The linux-alternatives 'priority' pillar value must be updated for each newly installed release/editions.
-
+Enable Debian alternatives by setting nonzero 'altpriority' pillar value; otherwise feature is disabled.
 
 Please see the pillar.example for configuration.
 Tested on Linux (Ubuntu, Fedora, Arch, and Suse), MacOS. Not verified on Windows OS.

--- a/intellij/defaults.yaml
+++ b/intellij/defaults.yaml
@@ -24,8 +24,9 @@ intellij:
     src_hashsum:
 
   linux:
-    altpriority: 170
     symlink: /usr/bin/intellij
+    #debian alternatives is disabled by default. Activated via pillar value.
+    altpriority: 0
 
   prefs:
     user: undefined_user

--- a/intellij/developer.sls
+++ b/intellij/developer.sls
@@ -26,11 +26,11 @@ intellij-desktop-shortcut-add:
     - runas: {{ intellij.prefs.user }}
     - require:
       - file: intellij-desktop-shortcut-add
-   {% else %}
+   {% elif grains.os not in ('Windows') %}
    #Linux
   file.managed:
     - source: salt://intellij/files/intellij.desktop
-    - name: {{ intellij.homes }}/{{ intellij.prefs.user }}/Desktop/intellij{{ intellij.jetbrains.edition }}.desktop
+    - name: {{ intellij.homes }}/{{ intellij.prefs.user }}/Desktop/intellij{{ intellij.jetbrains.edition }}E.desktop
     - user: {{ intellij.prefs.user }}
     - makedirs: True
       {% if salt['grains.get']('os_family') in ('Suse') %} 
@@ -45,6 +45,7 @@ intellij-desktop-shortcut-add:
     - context:
       home: {{ intellij.jetbrains.realhome }}
       command: {{ intellij.command }}
+      edition: {{ intellij.jetbrains.edition }}
    {% endif %}
 
 

--- a/intellij/files/intellij.desktop
+++ b/intellij/files/intellij.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Encoding=UTF-8
-Name=Jetbrains IDEA IntelliJ {{ edition }} edition
+Name=Jetbrains IDEA IntelliJ {{ edition }}E
 Comment=JetBrains IntelliJ IDEA (Java IDE)
 Icon={{ home }}/{{ command.split('.')[0] }}.png
 Exec={{ home }}/{{ command }}

--- a/intellij/init.sls
+++ b/intellij/init.sls
@@ -11,6 +11,7 @@ intellij-extract-dirs:
   file.directory:
     - names:
       - '{{ intellij.tmpdir }}'
+      - '{{ intellij.jetbrains.home }}'
 {% if grains.os not in ('MacOS', 'Windows') %}
       - '{{ intellij.jetbrains.realhome }}'
     - user: root

--- a/intellij/linuxenv.sls
+++ b/intellij/linuxenv.sls
@@ -22,7 +22,8 @@ intellij-config:
       home: '{{ intellij.jetbrains.home }}/intellij'
 
   # Debian alternatives
-  {% if grains.os_family not in ('Arch') %}
+  {% if intellij.linux.altpriority > 0 %}
+     {% if grains.os_family not in ('Arch') %}
 
 # Add intelliJhome to alternatives system
 intellij-home-alt-install:
@@ -57,6 +58,7 @@ intellij-alt-set:
     - onchanges:
       - alternatives: intellij-alt-install
 
+      {% endif %}
   {% endif %}
 
 {% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -4,8 +4,9 @@ intellij:
     #Default edition 'C' (community) or 'U' (Ultimate).
     edition: C
   linux:
-    #Increase priority for every version/edition installation
-    altpriority: 190
+    #Enable Debian alternatives feature by setting nonzero 'altpriority' value here.
+    #Increase same value on each subsequent software installation.
+    #altpriority: 170
   dl:
     retries: 1
     interval: 30


### PR DESCRIPTION
PR to fix minor issues-
1) **intellij.developer** not verified on Windows => add **elif not 'Windows'**
2) **intellij.init** must ensure /opt/jetbrains (intellij.jetbrains.home) directory exists
3) Fix missing '**edition**' context for intellij.desktop
4) Fix **intellij.desktop** filename
5) Enable Debian Alternatives via 'altpriority' pillar (otherwise disabled)

Verified on OpenSUSE Leap