### PR TITLE
Two minor tweaks to intellij defaults

### DIFF
--- a/intellij/defaults.yaml
+++ b/intellij/defaults.yaml
@@ -1,7 +1,7 @@
 #Default Look Dictionary
 
 intellij:
-  prefix: /usr/lib/jetbrains
+  prefix: /usr/local/jetbrains
   tmpdir: /tmp/jetbrainstmp
   command: /bin/idea.sh
   homes: /home

--- a/intellij/init.sls
+++ b/intellij/init.sls
@@ -19,6 +19,7 @@ intellij-extract-dirs:
     - mode: 755
 {% endif %}
     - makedirs: True
+    - clean: True
     - require_in:
       - intellij-download-archive
 


### PR DESCRIPTION
Two minor updates to formula:

1. Set "file.directory.clean: True" to clean extract directories fully.
2. Set default prefix to '/usr/local' 