### PR TITLE
Correction to map.jinja for linux OS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ========
-intellij
+jetbrains intellij
 ========
 
 Formula for latest IntelliJ IDE from Jetbrains. Supports both 'Community' (default), and 'Ultimate' editions.

--- a/intellij/map.jinja
+++ b/intellij/map.jinja
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 # vim: ft=jinja
 
-# Start with defaults, merge osmapping, then pillars.
-
-{% import_yaml 'intellij/defaults.yaml' as defs %}
 {% set osmap = salt['grains.filter_by']({
+        'default':{
+        },
         'MacOS':  { 'prefix' : '/Applications/IntelliJ IDEA',
                     'homes'  : '/Users',
                     'command': '/idea',
@@ -18,6 +17,9 @@
         },
   }, grain="os",
 ) %}
+
+# Start with defaults, merge osmapping, then pillars.
+{% import_yaml 'intellij/defaults.yaml' as defs %}
 {% do defs.intellij.update(osmap) %}
 {% set ide = salt['pillar.get']( 'intellij', default=defs.intellij, merge=True) %}
 


### PR DESCRIPTION
The last commit tested on MacOS inadvertently broke formula on linux.  Fixing this.
