### PR TITLE
Better group handling (posix/ADS)

### DIFF
--- a/intellij/defaults.yaml
+++ b/intellij/defaults.yaml
@@ -30,6 +30,7 @@ intellij:
 
   prefs:
     user:
+    group:
     #See https://www.jetbrains.com/help/idea/exporting-and-importing-settings.html
     jarurl:
     jardir:

--- a/intellij/map.jinja
+++ b/intellij/map.jinja
@@ -35,6 +35,12 @@
 {%- set src_hashurl = jdata[ pcode ][0]['downloads'][ ide.osflavour ]['checksumLink'] %}
 {%- set src_hashsum  = salt['cmd.run']('curl -s {0}'.format( src_hashurl )).split(' ')[0] %}
 
+# Get user's group name from pillar or 'id' command
+{%- if not ide.prefs.group %}
+  {%- set usergroup = salt['cmd.run']('id -gn', runas=intellij.prefs.user, output_loglevel='quiet',) or None %}
+  {%- do ide.prefs.update({'group': usergroup,}) %}
+{%- endif %}
+ 
 # Update dynamic parameters
 {% do ide.jetbrains.update({ 'realhome': _home, 'realcmd' : _home ~ ide.command },) %}
 {% do ide.dl.update({


### PR DESCRIPTION
Read group from either `pillar` or GNU coreutils `id` command.
