### PR TITLE
Always retry alternatives install/set states

### DIFF
--- a/intellij/linuxenv.sls
+++ b/intellij/linuxenv.sls
@@ -31,6 +31,9 @@ intellij-home-alt-install:
     - link: '{{ intellij.jetbrains.home }}/intellij'
     - path: '{{ intellij.jetbrains.realhome }}'
     - priority: {{ intellij.linux.altpriority }}
+    - retry:
+        attempts: 3
+        until: True
 
 intellij-home-alt-set:
   alternatives.set:
@@ -38,6 +41,9 @@ intellij-home-alt-set:
     - path: {{ intellij.jetbrains.realhome }}
     - onchanges:
       - alternatives: intellij-home-alt-install
+    - retry:
+        attempts: 3
+        until: True
 
 # Add to alternatives system
 intellij-alt-install:
@@ -49,6 +55,9 @@ intellij-alt-install:
     - require:
       - alternatives: intellij-home-alt-install
       - alternatives: intellij-home-alt-set
+    - retry:
+        attempts: 3
+        until: True
 
 intellij-alt-set:
   alternatives.set:
@@ -56,6 +65,9 @@ intellij-alt-set:
     - path: {{ intellij.jetbrains.realcmd }}
     - onchanges:
       - alternatives: intellij-alt-install
+    - retry:
+        attempts: 3
+        until: True
 
   {% endif %}
 

--- a/intellij/map.jinja
+++ b/intellij/map.jinja
@@ -16,7 +16,8 @@
 ) %}
 
 # Get dynamic release metadata
-{%- set pcode = ide.jetbrains.product ~ ide.jetbrains.edition %}
+{%- set pcode = ide.jetbrains.product %}
+{%- set pcode = pcode ~ ide.jetbrains.edition if ide.jetbrains.edition else pcode %}
 {%- set jdata = salt['cmd.run']('curl {0} -s {1}{2}'.format(ide.dl.opts, ide.jetbrains.uri, pcode))|load_yaml %}
 
 # Extract download details


### PR DESCRIPTION
This PR introduces retries for salt `alternatives.install & alternatives.set` states. 

**Four states fail on 1st run**
```
         ID: intellij-home-alt-install
    Function: alternatives.install
        Name: intellij-home
      Result: False
     Comment: Alternative for intellij-home not installed: update-alternatives: using /usr/local/jetbrains/intellij-C-2019.1 to provide /opt/jetbrains/intellij (intellij-home) in auto mode
     Started: 21:40:37.059927
    Duration: 9.856 ms
     Changes:   
----------
          ID: intellij-home-alt-set
    Function: alternatives.set
        Name: intellij-home
      Result: False
     Comment: One or more requisite failed: intellij.linuxenv.intellij-home-alt-install
     Changes:   
----------
          ID: intellij-alt-install
    Function: alternatives.install
        Name: intellij
      Result: False
     Comment: One or more requisite failed: intellij.linuxenv.intellij-home-alt-set, intellij.linuxenv.intellij-home-alt-install
     Changes:   
----------
          ID: intellij-alt-set
    Function: alternatives.set
        Name: intellij
      Result: False
     Comment: One or more requisite failed: intellij.linuxenv.intellij-alt-install
     Changes: 
```

**Two states fail on 2nd run**
````
   ID: intellij-home-alt-install
    Function: alternatives.install
        Name: intellij-home
      Result: True
     Comment: Alternatives for intellij-home is already set to /usr/local/jetbrains/intellij-C-2019.1
     Started: 21:43:24.512549
    Duration: 0.831 ms
     Changes:   
----------
          ID: intellij-home-alt-set
    Function: alternatives.set
        Name: intellij-home
      Result: True
     Comment: State was not run because none of the onchanges reqs changed
     Changes:   
----------
          ID: intellij-alt-install
    Function: alternatives.install
        Name: intellij
      Result: False
     Comment: Alternative for intellij not installed: update-alternatives: using /usr/local/jetbrains/intellij-C-2019.1/bin/idea.sh to provide /usr/bin/intellij (intellij) in auto mode
     Started: 21:43:24.514368
    Duration: 20.197 ms
     Changes:   
----------
          ID: intellij-alt-set
    Function: alternatives.set
        Name: intellij
      Result: False
     Comment: One or more requisite failed: intellij.linuxenv.intellij-alt-install
     Changes:   
````

**No states fail on 3rd run.**