### PR TITLE
fix(flavour): jetbrains osflavour value has changed

### DIFF
--- a/intellij/defaults.yaml
+++ b/intellij/defaults.yaml
@@ -5,7 +5,7 @@ intellij:
   tmpdir: /tmp/jetbrainstmp
   command: /bin/idea.sh
   homes: /home
-  osflavour: linuxWithoutJDK
+  osflavour: linuxWithoutJBR  #previously called linuxWithoutJDK
 
   jetbrains:
     home: /opt/jetbrains


### PR DESCRIPTION
This PR fixes formula on Linux.
I think the `linuxWithoutJDK` parameter was renamed`LinuxWithoutJBR`. 
see https://data.services.jetbrains.com/products/releases?code=IIC

```
    Rendering SLS 'base:intellij' failed: Jinja variable 'dict object' has
                             no attribute u'linuxWithoutJDK'
/var/cache/salt/minion/files/base/intellij/map.jinja(28):
---
[...]
# Extract download details
{%- set _home = '{0}/intellij-{1}-{2}'.format( ide.prefix, ide.jetbrains.edition, jdata[ pcode ][0]['version'],) %}
{%- if grains.os == 'MacOS' %}
  {%- set _home = '{0} {1}E.app/Contents/MacOS'.format(ide.prefix, ide.jetbrains.edition) %}
{% endif %}
{%- set src_hashurl = 
    jdata[ pcode ][0]['downloads'][ ide.osflavour ]['checksumLink'] %}    <===========
```

